### PR TITLE
Add base speculators configuration classes and tests

### DIFF
--- a/src/speculators/__init__.py
+++ b/src/speculators/__init__.py
@@ -1,0 +1,35 @@
+"""
+Speculators: A Unified Library for Speculative Decoding Algorithms for LLMs
+
+Speculators provides a standardized framework for creating, representing, and
+storing speculative decoding algorithms for large language model (LLM) inference.
+It enables developers to implement and productize various speculative decoding
+approaches with a consistent interface, making them ready for integration with
+LLM inference servers like vLLM.
+
+Speculative decoding is a technique that can significantly improve LLM inference
+performance by predicting multiple tokens with a smaller, speculative model and
+then verifying the predictions with the original, larger model.
+This approach tradesoff extra computation for reduced latency, making it suitable
+for real-time applications on deployments that are not compute-constrained.
+
+The library offers a modular architecture with components for:
+- Standardized interfaces for working with speculative decoding algorithms that
+  build on top of Transformers pathways for simple integration.
+- Centralized definition, configuration, and validation of speculative decoding
+  algorithms.
+"""
+
+from .config import (
+    SpeculatorModelConfig,
+    SpeculatorsConfig,
+    TokenProposalConfig,
+    VerifierConfig,
+)
+
+__all__ = [
+    "SpeculatorModelConfig",
+    "SpeculatorsConfig",
+    "TokenProposalConfig",
+    "VerifierConfig",
+]

--- a/src/speculators/__init__.py
+++ b/src/speculators/__init__.py
@@ -10,7 +10,7 @@ LLM inference servers like vLLM.
 Speculative decoding is a technique that can significantly improve LLM inference
 performance by predicting multiple tokens with a smaller, speculative model and
 then verifying the predictions with the original, larger model.
-This approach tradesoff extra computation for reduced latency, making it suitable
+This approach trades off extra computation for reduced latency, making it suitable
 for real-time applications on deployments that are not compute-constrained.
 
 The library offers a modular architecture with components for:

--- a/src/speculators/config.py
+++ b/src/speculators/config.py
@@ -57,7 +57,7 @@ class TokenProposalConfig(BaseModel):
 class VerifierConfig(BaseModel):
     """
     The base config for a verifier model which defines the parameters that are required
-    to either load the original verifier model or validate compatability with a new
+    to either load the original verifier model or validate compatibility with a new
     verifier based on the the architecture and tokenizers/processor properties.
     It provides convenience methods to extract the required parameters from a
     PretrainedConfig object.
@@ -100,35 +100,35 @@ class VerifierConfig(BaseModel):
     architectures: list[str] = Field(
         description=(
             "The architectures for the original verifier as found in its config.json. "
-            "Used to validate architecture compatability of different verifiers "
-            "with the speculatorm, if needed."
+            "Used to validate architecture compatibility of different verifiers "
+            "with the speculator, if needed."
         ),
     )
     hidden_size: int = Field(
         description=(
             "The hidden size of the original verifier as found in its config.json. "
-            "Used to validate architecture compatability of different verifiers "
+            "Used to validate architecture compatibility of different verifiers "
             "with the speculator, if needed."
         ),
     )
     intermediate_size: int = Field(
         description=(
             "The intermediate size of original verifier as found in its config.json. "
-            "Used to validate architecture compatability of different verifiers "
+            "Used to validate architecture compatibility of different verifiers "
             "with the speculator, if needed."
         ),
     )
     vocab_size: int = Field(
         description=(
             "The vocab size of the original verifier as found in the its config.json. "
-            "Used to validate tokenizer compatability of different verifiers "
+            "Used to validate tokenizer compatibility of different verifiers "
             "with the speculator, if needed."
         ),
     )
     max_position_embeddings: int = Field(
         description=(
             "The max position embeddings of original verifier as in its config.json. "
-            "Used to validate max length compatability of different verifiers "
+            "Used to validate max length compatibility of different verifiers "
             "with the speculator, if needed."
         ),
     )
@@ -136,7 +136,7 @@ class VerifierConfig(BaseModel):
         description=(
             "The beginning of sentence token id of the original verifier as "
             "found in its config.json. "
-            "Used to validate tokenizer compatability of different verifiers "
+            "Used to validate tokenizer compatibility of different verifiers "
             "with the speculator, if needed."
         ),
     )
@@ -144,7 +144,7 @@ class VerifierConfig(BaseModel):
         description=(
             "The end of sentence token id of the original verifier as "
             "found in its config.json. "
-            "Used to validate tokenizer compatability of different verifiers "
+            "Used to validate tokenizer compatibility of different verifiers "
             "with the speculator, if needed."
         ),
     )
@@ -180,7 +180,7 @@ class SpeculatorsConfig(BaseModel):
             "The config for the verifier the speculator was created for. "
             "Used to auto load the verifier when the speculator is loaded, if needed. "
             "Also used to validate the verifier architecture and tokenizer "
-            "compatability for a new verifier, if needed."
+            "compatibility for a new verifier, if needed."
         ),
     )
 
@@ -193,7 +193,7 @@ class SpeculatorModelConfig(BaseModel, PretrainedConfig):
     speculators config describing the algorithm, token proposals, and verifier model.
 
     It inherits from the Transformers PretrainedConfig class to ensure full
-    compatability with standard Transformers model pathways while building on
+    compatibility with standard Transformers model pathways while building on
     the standard methods for PretrainedConfigs to load, save, and push to the HF hub.
 
     This is the main config which maps to the config.json file for saved speculators.
@@ -250,3 +250,11 @@ class SpeculatorModelConfig(BaseModel, PretrainedConfig):
             PretrainedConfig variables.
         """
         return self.model_dump()
+
+    def to_diff_dict(self) -> dict[str, Any]:
+        """
+        :return: A dictionary representation of the config minus any base
+            properties that are not needed for the diff. Uses the super's
+            to_diff_dict method.
+        """
+        return super().to_diff_dict()

--- a/src/speculators/config.py
+++ b/src/speculators/config.py
@@ -1,0 +1,252 @@
+"""
+Configuration classes for Speculators library.
+
+This module contains the configuration classes for speculative decoding
+implementations in the Speculators library. These includes configurations for
+token proposal methods, verifier models, speculative decoding algorithms,
+and speculator models.
+
+The configurations use Pydantic for validation, serialization, and deserialization,
+and extend Hugging Face's PretrainedConfig where appropriate to maintain compatibility
+with the transformers ecosystem.
+
+Classes:
+    TokenProposalConfig: Base configuration for token proposal methods
+    VerifierConfig: Configuration for verifier models with compatibility validation
+    SpeculatorsConfig: Configuration for speculative decoding implementations
+    SpeculatorModelConfig: Configuration for speculator models with transformers
+        compatibility
+"""
+
+import os
+from importlib.metadata import version
+from typing import Any, ClassVar, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+from transformers import PretrainedConfig
+
+__all__ = [
+    "SpeculatorModelConfig",
+    "SpeculatorsConfig",
+    "TokenProposalConfig",
+    "VerifierConfig",
+]
+
+
+class TokenProposalConfig(BaseModel):
+    """
+    The base config for a token proposal method which defines how tokens are generated
+    by the speculator, how they are passed to the verifier, and how they are scored
+    for acceptance or rejection. All implementations of token proposal methods
+    must inherit from this class, set the proposal_type to a unique value, and
+    add any additional parameters needed to instantiate and implement the method.
+
+    It uses pydantic to validate the parameters, provide default values, and
+    enable automatic serialization and deserialization of the correct class
+    types based on the proposal_type field.
+    """
+
+    proposal_type: str = Field(
+        description=(
+            "The type of token proposal the config is for. "
+            "Must be a supported proposal type from the Speculators repo."
+        ),
+    )
+
+
+class VerifierConfig(BaseModel):
+    """
+    The base config for a verifier model which defines the parameters that are required
+    to either load the original verifier model or validate compatability with a new
+    verifier based on the the architecture and tokenizers/processor properties.
+    It provides convenience methods to extract the required parameters from a
+    PretrainedConfig object.
+    """
+
+    @classmethod
+    def from_verifier_config(
+        cls, config: PretrainedConfig, name_or_path: Optional[str] = None
+    ) -> "VerifierConfig":
+        """
+        Create a VerifierConfig from a PretrainedConfig object.
+        Used to extract the required parameters from the original verifier
+        config and create a VerifierConfig object.
+
+        :param config: The PretrainedConfig object to extract the parameters from.
+        :param name_or_path: The name or path for the verifier model.
+            If not provided, the name_or_path from the config will be used.
+        :return: A VerifierConfig object with the extracted parameters.
+        """
+        config_dict = config.to_dict()
+
+        return cls(
+            name_or_path=name_or_path or config.name_or_path,
+            architectures=config_dict.get("architectures", []),
+            hidden_size=config_dict.get("hidden_size", -1),
+            intermediate_size=config_dict.get("intermediate_size", -1),
+            vocab_size=config_dict.get("vocab_size", -1),
+            max_position_embeddings=config_dict.get("max_position_embeddings", -1),
+            bos_token_id=config_dict.get("bos_token_id", -1),
+            eos_token_id=config_dict.get("eos_token_id", -1),
+        )
+
+    name_or_path: str = Field(
+        description=(
+            "The name as a Hugging Face id or path to the verifier model "
+            "used for the speculator. Used to dynamically load the verifier the "
+            "speculator was created for."
+        ),
+    )
+    architectures: list[str] = Field(
+        description=(
+            "The architectures for the original verifier as found in its config.json. "
+            "Used to validate architecture compatability of different verifiers "
+            "with the speculatorm, if needed."
+        ),
+    )
+    hidden_size: int = Field(
+        description=(
+            "The hidden size of the original verifier as found in its config.json. "
+            "Used to validate architecture compatability of different verifiers "
+            "with the speculator, if needed."
+        ),
+    )
+    intermediate_size: int = Field(
+        description=(
+            "The intermediate size of original verifier as found in its config.json. "
+            "Used to validate architecture compatability of different verifiers "
+            "with the speculator, if needed."
+        ),
+    )
+    vocab_size: int = Field(
+        description=(
+            "The vocab size of the original verifier as found in the its config.json. "
+            "Used to validate tokenizer compatability of different verifiers "
+            "with the speculator, if needed."
+        ),
+    )
+    max_position_embeddings: int = Field(
+        description=(
+            "The max position embeddings of original verifier as in its config.json. "
+            "Used to validate max length compatability of different verifiers "
+            "with the speculator, if needed."
+        ),
+    )
+    bos_token_id: Union[int, list[int]] = Field(
+        description=(
+            "The beginning of sentence token id of the original verifier as "
+            "found in its config.json. "
+            "Used to validate tokenizer compatability of different verifiers "
+            "with the speculator, if needed."
+        ),
+    )
+    eos_token_id: Union[int, list[int]] = Field(
+        description=(
+            "The end of sentence token id of the original verifier as "
+            "found in its config.json. "
+            "Used to validate tokenizer compatability of different verifiers "
+            "with the speculator, if needed."
+        ),
+    )
+
+
+class SpeculatorsConfig(BaseModel):
+    """
+    The base config for a spec decode implementation which defines the parameters
+    required to implement a speculators algorithm for the parent, speculator model.
+    It includes details on the algorithm, token proposals, and the verifier model.
+    """
+
+    algorithm: str = Field(
+        description=(
+            "The speculative decoding algorithm the speculator implements. "
+            "Must be an algorithm name from the Speculators library. "
+        ),
+    )
+    proposal_methods: list[TokenProposalConfig] = Field(
+        description=(
+            "The token proposal methods supported by the speculator. "
+            "Must be a list of supported proposal configs from the Speculators repo."
+        ),
+    )
+    default_proposal_method: str = Field(
+        description=(
+            "The default token proposal method to use when no method is specified. "
+            "Must be the proposal_type for one of items in the proposal_methods list."
+        ),
+    )
+    verifier: VerifierConfig = Field(
+        description=(
+            "The config for the verifier the speculator was created for. "
+            "Used to auto load the verifier when the speculator is loaded, if needed. "
+            "Also used to validate the verifier architecture and tokenizer "
+            "compatability for a new verifier, if needed."
+        ),
+    )
+
+
+class SpeculatorModelConfig(BaseModel, PretrainedConfig):
+    """
+    The base config for a speculator model and implementation which defines the
+    hyperparameters and settings required to implement a speculator model.
+    It includes details on the speculator model architecture along with the
+    speculators config describing the algorithm, token proposals, and verifier model.
+
+    It inherits from the Transformers PretrainedConfig class to ensure full
+    compatability with standard Transformers model pathways while building on
+    the standard methods for PretrainedConfigs to load, save, and push to the HF hub.
+
+    This is the main config which maps to the config.json file for saved speculators.
+    """
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: Union[str, os.PathLike],
+        cache_dir: Optional[Union[str, os.PathLike]] = None,
+        force_download: bool = False,
+        local_files_only: bool = False,
+        token: Optional[Union[str, bool]] = None,
+        revision: str = "main",
+        **kwargs,
+    ) -> "SpeculatorModelConfig":
+        """
+        Load a SpeculatorModelConfig from the name/id of a model on the Hugging Face Hub
+        or from a local directory. Will automatically instantiate the correct config
+        from speculators.models package.
+
+        :param pretrained_model_name_or_path: The name or path to the pretrained model.
+        :param cache_dir: The directory to cache the config in.
+        :param force_download: Whether to force download the config from the Hub.
+        :param local_files_only: Whether to use local files, not download from the Hub.
+        :param token: The token to use for authentication with the Hub.
+        :param revision: The revision of the config to load from the Hub.
+        :param kwargs: Additional keyword arguments to pass to the config.
+        :return: A SpeculatorModelConfig object with the loaded parameters.
+        """
+        raise NotImplementedError("from_pretrained is not implemented yet.")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    # Get around to_diff_dict constructor
+    is_composition: ClassVar[bool] = True  # type: ignore[misc]
+
+    speculators_model_type: str = Field(
+        description=("The type of model from the Speculators repo this config is for.")
+    )
+    speculators_version: str = Field(
+        default=version("speculators"),
+        description="Version of the speculators library",
+    )
+    speculators_config: SpeculatorsConfig = Field(
+        description=(
+            "The speculators config describing what the model implements and creation. "
+            "Contains information about the algorithm, proposal methods, and verifier."
+        ),
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        :return: A dictionary representation of the full config, including the
+            PretrainedConfig variables.
+        """
+        return self.model_dump()

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for the config module in the Speculators library.
+"""
+
+import tempfile
+
+import pytest
+from transformers import PretrainedConfig
+
+from speculators import (
+    SpeculatorModelConfig,
+    VerifierConfig,
+)
+
+# ===== VerifierConfig Tests =====
+
+
+@pytest.mark.smoke
+def test_verifier_config_from_verifier_config():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pretrained_config = PretrainedConfig.from_pretrained(
+            pretrained_model_name_or_path="RedHatAI/Llama-3.1-8B-Instruct",
+            cache_dir=tmp_dir,
+        )
+
+    config = VerifierConfig.from_verifier_config(
+        pretrained_config, name_or_path="RedHatAI/Llama-3.1-8B-Instruct"
+    )
+    assert config.name_or_path == "RedHatAI/Llama-3.1-8B-Instruct"
+    assert config.architectures == ["LlamaForCausalLM"]
+    assert config.hidden_size == 4096
+    assert config.intermediate_size == 14336
+    assert config.vocab_size == 128256
+    assert config.max_position_embeddings == 131072
+    assert config.bos_token_id == 128000
+    assert config.eos_token_id == [128001, 128008, 128009]
+
+
+# ===== SpeculatorModelConfig Tests =====
+
+
+@pytest.mark.smoke
+def test_speculator_model_config_from_pretrained():
+    # swap for real config once implemented
+    with pytest.raises(NotImplementedError) as exc_info:
+        SpeculatorModelConfig.from_pretrained("test/model")
+
+    assert "from_pretrained is not implemented yet" in str(exc_info.value)
+
+
+@pytest.mark.regression
+def test_speculator_model_config_pretrained_methods():
+    # Implement saving once real config is available
+    assert True

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -1,6 +1,0 @@
-import pytest
-
-
-@pytest.mark.smoke
-def test_placeholder():
-    assert True

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,345 @@
+"""
+Unit tests for the config module in the Speculators library.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+from transformers import PretrainedConfig
+
+from speculators import (
+    SpeculatorModelConfig,
+    SpeculatorsConfig,
+    TokenProposalConfig,
+    VerifierConfig,
+)
+
+# ===== TokenProposalConfig Tests =====
+
+
+@pytest.mark.smoke
+def test_token_proposal_config_initialization():
+    config = TokenProposalConfig(proposal_type="test_proposal")
+    assert config.proposal_type == "test_proposal"
+
+
+@pytest.mark.smoke
+def test_token_proposal_config_invalid_initialization():
+    with pytest.raises(ValidationError) as exc_info:
+        TokenProposalConfig()  # type: ignore[call-arg]
+
+    assert "proposal_type" in str(exc_info.value)
+    assert "Field required" in str(exc_info.value)
+
+
+@pytest.mark.sanity
+def test_token_proposal_config_marshalling():
+    original_config = TokenProposalConfig(proposal_type="test_proposal")
+
+    config_dict = original_config.model_dump()
+    assert isinstance(config_dict, dict)
+    assert config_dict["proposal_type"] == "test_proposal"
+
+    recreated_config = TokenProposalConfig.model_validate(config_dict)
+    assert recreated_config.proposal_type == original_config.proposal_type
+
+
+# ===== VerifierConfig Tests =====
+
+
+@pytest.fixture
+def mock_pretrained_config():
+    config = MagicMock(spec=PretrainedConfig)
+    config.name_or_path = "test/verifier"
+    config.to_dict.return_value = {
+        "architectures": ["TestModel"],
+        "hidden_size": 768,
+        "intermediate_size": 3072,
+        "vocab_size": 50000,
+        "max_position_embeddings": 512,
+        "bos_token_id": 1,
+        "eos_token_id": 2,
+    }
+    return config
+
+
+@pytest.mark.smoke
+def test_verifier_config_initialization():
+    config = VerifierConfig(
+        name_or_path="test/verifier",
+        architectures=["TestModel"],
+        hidden_size=768,
+        intermediate_size=3072,
+        vocab_size=50000,
+        max_position_embeddings=512,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+
+    assert config.name_or_path == "test/verifier"
+    assert config.architectures == ["TestModel"]
+    assert config.hidden_size == 768
+    assert config.intermediate_size == 3072
+    assert config.vocab_size == 50000
+    assert config.max_position_embeddings == 512
+    assert config.bos_token_id == 1
+    assert config.eos_token_id == 2
+
+
+@pytest.mark.smoke
+def test_verifier_config_from_verifier_config(mock_pretrained_config):
+    config = VerifierConfig.from_verifier_config(mock_pretrained_config)
+
+    assert config.name_or_path == "test/verifier"
+    assert config.architectures == ["TestModel"]
+    assert config.hidden_size == 768
+    assert config.intermediate_size == 3072
+    assert config.vocab_size == 50000
+    assert config.max_position_embeddings == 512
+    assert config.bos_token_id == 1
+    assert config.eos_token_id == 2
+
+
+@pytest.mark.smoke
+def test_verifier_config_invalid_initialization():
+    with pytest.raises(ValidationError) as exc_info:
+        VerifierConfig()  # type: ignore[call-arg]
+
+    error_str = str(exc_info.value)
+    assert "name_or_path" in error_str
+    assert "architectures" in error_str
+    assert "hidden_size" in error_str
+    assert "intermediate_size" in error_str
+    assert "vocab_size" in error_str
+    assert "max_position_embeddings" in error_str
+    assert "bos_token_id" in error_str
+    assert "eos_token_id" in error_str
+
+
+@pytest.mark.sanity
+def test_verifier_config_marshalling():
+    original_config = VerifierConfig(
+        name_or_path="test/verifier",
+        architectures=["TestModel"],
+        hidden_size=768,
+        intermediate_size=3072,
+        vocab_size=50000,
+        max_position_embeddings=512,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+
+    config_dict = original_config.model_dump()
+    assert isinstance(config_dict, dict)
+    assert config_dict["name_or_path"] == "test/verifier"
+    assert config_dict["architectures"] == ["TestModel"]
+    assert config_dict["hidden_size"] == 768
+
+    recreated_config = VerifierConfig.model_validate(config_dict)
+    assert recreated_config.name_or_path == original_config.name_or_path
+    assert recreated_config.architectures == original_config.architectures
+    assert recreated_config.hidden_size == original_config.hidden_size
+
+
+# ===== SpeculatorsConfig Tests =====
+
+
+@pytest.fixture
+def sample_token_proposal_config():
+    return TokenProposalConfig(proposal_type="test_proposal")
+
+
+@pytest.fixture
+def sample_verifier_config():
+    return VerifierConfig(
+        name_or_path="test/verifier",
+        architectures=["TestModel"],
+        hidden_size=768,
+        intermediate_size=3072,
+        vocab_size=50000,
+        max_position_embeddings=512,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+
+
+@pytest.mark.smoke
+def test_speculators_config_initialization(
+    sample_token_proposal_config, sample_verifier_config
+):
+    config = SpeculatorsConfig(
+        algorithm="test_algorithm",
+        proposal_methods=[sample_token_proposal_config],
+        default_proposal_method="test_proposal",
+        verifier=sample_verifier_config,
+    )
+
+    assert config.algorithm == "test_algorithm"
+    assert len(config.proposal_methods) == 1
+    assert config.proposal_methods[0].proposal_type == "test_proposal"
+    assert config.default_proposal_method == "test_proposal"
+    assert config.verifier.name_or_path == "test/verifier"
+
+
+@pytest.mark.smoke
+def test_speculators_config_invalid_initialization(
+    sample_token_proposal_config, sample_verifier_config
+):
+    with pytest.raises(ValidationError) as exc_info:
+        SpeculatorsConfig()  # type: ignore[call-arg]
+
+    error_str = str(exc_info.value)
+    assert "algorithm" in error_str
+    assert "proposal_methods" in error_str
+    assert "default_proposal_method" in error_str
+    assert "verifier" in error_str
+
+
+@pytest.mark.sanity
+def test_speculators_config_marshalling(
+    sample_token_proposal_config, sample_verifier_config
+):
+    original_config = SpeculatorsConfig(
+        algorithm="test_algorithm",
+        proposal_methods=[sample_token_proposal_config],
+        default_proposal_method="test_proposal",
+        verifier=sample_verifier_config,
+    )
+
+    config_dict = original_config.model_dump()
+    assert isinstance(config_dict, dict)
+    assert config_dict["algorithm"] == "test_algorithm"
+    assert len(config_dict["proposal_methods"]) == 1
+    assert config_dict["proposal_methods"][0]["proposal_type"] == "test_proposal"
+    assert config_dict["default_proposal_method"] == "test_proposal"
+
+    recreated_config = SpeculatorsConfig.model_validate(config_dict)
+    assert recreated_config.algorithm == original_config.algorithm
+    assert (
+        recreated_config.proposal_methods[0].proposal_type
+        == original_config.proposal_methods[0].proposal_type
+    )
+    assert (
+        recreated_config.default_proposal_method
+        == original_config.default_proposal_method
+    )
+    assert (
+        recreated_config.verifier.name_or_path == original_config.verifier.name_or_path
+    )
+
+
+# ===== SpeculatorModelConfig Tests =====
+
+
+@pytest.fixture
+def sample_speculators_config(sample_token_proposal_config, sample_verifier_config):
+    return SpeculatorsConfig(
+        algorithm="test_algorithm",
+        proposal_methods=[sample_token_proposal_config],
+        default_proposal_method="test_proposal",
+        verifier=sample_verifier_config,
+    )
+
+
+@pytest.mark.smoke
+def test_speculator_model_config_initialization(sample_speculators_config):
+    config = SpeculatorModelConfig(
+        speculators_model_type="test_model",
+        speculators_config=sample_speculators_config,
+    )
+
+    assert config.speculators_model_type == "test_model"
+    assert config.speculators_config.algorithm == "test_algorithm"
+    assert config.speculators_version is not None
+
+    # Check that PretrainedConfig attributes are accessible
+    assert hasattr(config, "to_dict")
+    assert hasattr(config, "to_diff_dict")
+    assert hasattr(config, "to_json_string")
+    assert hasattr(config, "to_json_file")
+    assert hasattr(config, "save_pretrained")
+
+
+@pytest.mark.smoke
+def test_speculator_model_config_invalid_initialization(sample_speculators_config):
+    with pytest.raises(ValidationError) as exc_info:
+        SpeculatorModelConfig()  # type: ignore[call-arg]
+
+    error_str = str(exc_info.value)
+    assert "speculators_model_type" in error_str
+    assert "speculators_config" in error_str
+
+
+@pytest.mark.sanity
+def test_speculator_model_config_marshalling(sample_speculators_config):
+    original_config = SpeculatorModelConfig(
+        speculators_model_type="test_model",
+        speculators_config=sample_speculators_config,
+    )
+
+    config_dict = original_config.model_dump()
+    assert isinstance(config_dict, dict)
+    assert config_dict["speculators_model_type"] == "test_model"
+    assert config_dict["speculators_config"]["algorithm"] == "test_algorithm"
+
+    recreated_config = SpeculatorModelConfig.model_validate(config_dict)
+    assert (
+        recreated_config.speculators_model_type
+        == original_config.speculators_model_type
+    )
+    assert (
+        recreated_config.speculators_config.algorithm
+        == original_config.speculators_config.algorithm
+    )
+
+
+@pytest.mark.smoke
+def test_speculator_model_config_from_pretrained():
+    with pytest.raises(NotImplementedError) as exc_info:
+        SpeculatorModelConfig.from_pretrained("test/model")
+
+    assert "from_pretrained is not implemented yet" in str(exc_info.value)
+
+
+@pytest.mark.regression
+def test_speculator_model_config_pretrained_methods(sample_speculators_config):
+    config = SpeculatorModelConfig(
+        speculators_model_type="test_model",
+        speculators_config=sample_speculators_config,
+    )
+
+    # Test to_dict and to_diff_dict
+    config_dict = config.to_dict()
+    assert isinstance(config_dict, dict)
+    assert "speculators_model_type" in config_dict
+    assert "speculators_config" in config_dict
+
+    diff_dict = config.to_diff_dict()
+    assert isinstance(diff_dict, dict)
+    assert "speculators_model_type" in diff_dict
+    # Test to_json_string
+    json_string = config.to_json_string()
+    assert isinstance(json_string, str)
+    parsed_json = json.loads(json_string)
+    assert parsed_json["speculators_model_type"] == "test_model"
+
+    # Test to_json_file and save_pretrained
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        json_path = tmp_path / "config.json"
+        config.to_json_file(json_path)
+        assert json_path.exists()
+
+        save_dir = tmp_path / "save_dir"
+        config.save_pretrained(save_dir)
+        assert (save_dir / "config.json").exists()
+        # Load the saved file and verify contents
+        with (save_dir / "config.json").open() as file:
+            saved_dict = json.load(file)
+
+        assert saved_dict["speculators_model_type"] == "test_model"
+        assert saved_dict["speculators_config"]["algorithm"] == "test_algorithm"

--- a/tests/unit/test_placeholder.py
+++ b/tests/unit/test_placeholder.py
@@ -1,6 +1,0 @@
-import pytest
-
-
-@pytest.mark.smoke
-def test_placeholder():
-    assert True


### PR DESCRIPTION
## Summary

Added the base required configuration classes for speculators and associated unit and integration tests:
- SpeculatorModelConfig (root)
- SpeculatorsConfig (contained in model config)
- TokenProposalConfig (contained in speculators config)
- VerifierConfig (contained in speculators config)

## Testing

Added tests to cover the newly added configurations. Tests will need to be updated in later revisions to test subsequently added functionality such as from_pretrained.