### PR TITLE
Migrate link checks to GitHub actions only with lychee for main workflows

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -37,22 +37,6 @@ jobs:
       - name: Run quality checks
         run: tox -e types
 
-  link-checks:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.9"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
-      - name: Run link checks
-        run: tox -e links
-
   precommit-checks:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,22 +38,6 @@ jobs:
       - name: Run quality checks
         run: tox -e types
 
-  link-checks:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.9"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
-      - name: Run link checks
-        run: tox -e links
-
   precommit-checks:
     runs-on: ubuntu-latest
     strategy:
@@ -69,6 +53,30 @@ jobs:
         run: pip install pre-commit
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+
+  link-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+      - name: Create Issues
+        if: steps.lychee.outputs.exit_code != '0'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue
+      - name: Fail on Issues
+        if: steps.lychee.outputs.exit_code != '0'
+        run: |
+          echo "Link Checker found issues. Please check the created issue for details."
+          exit 1
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,19 +7,27 @@ on:
 jobs:
   link-checks:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.9"]
+    permissions:
+      issues: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
         with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
-      - name: Run link checks
-        run: tox -e links
+          fail: false
+      - name: Create Issues
+        if: steps.lychee.outputs.exit_code != '0'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue
+      - name: Fail on Issues
+        if: steps.lychee.outputs.exit_code != '0'
+        run: |
+          echo "Link Checker found issues. Please check the created issue for details."
+          exit 1
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -61,15 +61,6 @@ commands =
     mypy --check-untyped-defs
 
 
-[testenv:links]
-description = Run link checks for root and docs markdown files
-deps =
-    .[dev]
-commands =
-    mkdocs-linkcheck ./
-    mkdocs-linkcheck docs/
-
-
 [testenv:build]
 description = Build the project
 deps =


### PR DESCRIPTION
Fixes link checking issues failing on GitHub actions and failing to run locally by removing the local ability (lychee requires non-straightforward install pathways based on development OS)