### PR TITLE
chore: Update pr comment behavior

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -117,23 +117,21 @@ jobs:
           compression-level: 6
           if-no-files-found: error
           retention-days: 30
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+      - name: Find comment
+        uses: peter-evans/find-comment@v3
+        id: fc
         with:
-          app-id: ${{ secrets.GH_NM_REDHAT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.GH_NM_REDHAT_AUTOMATION_APP_PRIVATE_KEY }}
-      - name: Comment Install instructions
-        uses: actions/github-script@v7
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Build Artifacts Available
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `📦 **Build Artifacts Available**
-              The build artifacts (\`.whl\` and \`.tar.gz\`) have been successfully generated and are available for download: ${{ steps.artifact-upload.outputs.artifact-url }}.
-              They will be retained for **up to 30 days**.
-              `
-            })
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            📦 **Build Artifacts Available**
+            The build artifacts (\`.whl\` and \`.tar.gz\`) have been successfully generated and are available for download: ${{ steps.artifact-upload.outputs.artifact-url }}.
+            They will be retained for **up to 30 days**.
+            Commit: ${{ github.event.pull_request.head.sha }}
+          edit-mode: replace


### PR DESCRIPTION
Currently every pr commit results in a new comment like https://github.com/neuralmagic/speculators/pull/39#issuecomment-3020058659 which clutters the pr.

This pr changes the behavior so that new builds edit the existing comment instead of creating a new one. Previous comments can be seen by looking at the revision history of the comment.

Note: this uses the existing Github token, instead of the automation bot token but could be updated to use that token instead if that's preferred. 