### PR TITLE
feat: Expand Eagle Speculator to Support Multiple Transformer Layer Types

### DIFF
--- a/src/speculators/models/eagle.py
+++ b/src/speculators/models/eagle.py
@@ -16,7 +16,7 @@ from typing import Any, ClassVar, Literal, Optional, Union
 import torch
 from pydantic import Field, field_serializer, field_validator, model_validator
 from torch import nn
-from transformers import PretrainedConfig, PreTrainedModel
+from transformers import AutoConfig, PretrainedConfig, PreTrainedModel
 from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.llama.configuration_llama import LlamaConfig
@@ -163,8 +163,7 @@ class EagleSpeculatorConfig(SpeculatorModelConfig):
         :raises ValueError: If the value cannot be converted to a PretrainedConfig
         """
         if isinstance(value, dict):
-            return PretrainedConfig.from_dict(value)
-
+            return AutoConfig.for_model(**value)
         if isinstance(value, PretrainedConfig):
             return value
 

--- a/tests/unit/models/test_eagle_config.py
+++ b/tests/unit/models/test_eagle_config.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 from pydantic import BaseModel, ValidationError
+from transformers import PretrainedConfig
+from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+from transformers.models.gemma.configuration_gemma import GemmaConfig
+from transformers.models.granite.configuration_granite import GraniteConfig
 from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.mistral.configuration_mistral import MistralConfig
+from transformers.models.mixtral.configuration_mixtral import MixtralConfig
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
 from speculators import (
     SpeculatorModelConfig,
@@ -16,6 +23,18 @@ from speculators import (
 )
 from speculators.models import EagleSpeculatorConfig
 from speculators.proposals import GreedyTokenProposalConfig
+
+LAYER_TYPES: list[tuple[str, type[PretrainedConfig]]] = [
+    ("LlamaDecoderLayer", LlamaConfig),
+    ("MistralDecoderLayer", MistralConfig),
+    ("Qwen3DecoderLayer", Qwen3Config),
+    ("GemmaDecoderLayer", GemmaConfig),
+    ("MixtralDecoderLayer", MixtralConfig),
+    ("DeepseekV3DecoderLayer", DeepseekV3Config),
+    ("GraniteDecoderLayer", GraniteConfig),
+]
+
+LAYER_ARCHITECTURES = [arch for arch, _ in LAYER_TYPES]
 
 # ===== Fixtures =====
 
@@ -57,6 +76,105 @@ def sample_llama_config():
         num_attention_heads=12,
         max_position_embeddings=2048,
     )
+
+
+@pytest.fixture
+def sample_mistral_config():
+    return MistralConfig(
+        vocab_size=32000,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        max_position_embeddings=2048,
+    )
+
+
+@pytest.fixture
+def sample_qwen3_config():
+    return Qwen3Config(
+        vocab_size=32000,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        max_position_embeddings=2048,
+    )
+
+
+@pytest.fixture
+def sample_gemma_config():
+    return GemmaConfig(
+        vocab_size=32000,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        max_position_embeddings=2048,
+    )
+
+
+@pytest.fixture
+def sample_mixtral_config():
+    return MixtralConfig(
+        vocab_size=32000,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        num_key_value_heads=12,
+        max_position_embeddings=2048,
+        num_local_experts=8,
+        num_experts_per_tok=2,
+    )
+
+
+@pytest.fixture
+def sample_deepseek_config():
+    return DeepseekV3Config(
+        vocab_size=32000,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        num_key_value_heads=12,
+        max_position_embeddings=2048,
+    )
+
+
+@pytest.fixture
+def sample_granite_config():
+    return GraniteConfig(
+        vocab_size=32000,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        num_key_value_heads=12,
+        max_position_embeddings=2048,
+    )
+
+
+@pytest.fixture
+def layer_configs(
+    sample_llama_config,
+    sample_mistral_config,
+    sample_qwen3_config,
+    sample_gemma_config,
+    sample_mixtral_config,
+    sample_deepseek_config,
+    sample_granite_config,
+):
+    """Return a mapping of layer architectures to their configurations."""
+    return {
+        "LlamaDecoderLayer": sample_llama_config,
+        "MistralDecoderLayer": sample_mistral_config,
+        "Qwen3DecoderLayer": sample_qwen3_config,
+        "GemmaDecoderLayer": sample_gemma_config,
+        "MixtralDecoderLayer": sample_mixtral_config,
+        "DeepseekV3DecoderLayer": sample_deepseek_config,
+        "GraniteDecoderLayer": sample_granite_config,
+    }
 
 
 @pytest.fixture
@@ -131,6 +249,24 @@ def test_eagle_speculator_config_initialization():
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_config_different_layers(layer_architecture, layer_configs):
+    """Test initialization with different layer architectures."""
+    layer_config = layer_configs[layer_architecture]
+
+    config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+    )
+
+    # Verify the correct layer architecture is set
+    assert config.transformer_layer_architecture == layer_architecture
+    assert layer_architecture in config.architectures
+    assert "EagleSpeculator" in config.architectures
+    assert config.transformer_layer_config == layer_config
+
+
+@pytest.mark.smoke
 def test_eagle_speculator_config_custom_initialization(
     sample_speculators_config, sample_llama_config
 ):
@@ -153,6 +289,35 @@ def test_eagle_speculator_config_custom_initialization(
     assert config.layernorms is True
     assert config.fusion_bias is True
     assert config.speculators_config == sample_speculators_config
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(("layer_architecture", "config_class"), LAYER_TYPES)
+def test_eagle_speculator_config_with_different_configs(
+    layer_architecture, config_class, sample_speculators_config
+):
+    """Test EagleSpeculatorConfig with different transformer layer configurations."""
+    layer_config = config_class(
+        vocab_size=32000,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        max_position_embeddings=2048,
+    )
+
+    config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        speculators_config=sample_speculators_config,
+    )
+
+    # Verify the configuration
+    assert config.transformer_layer_architecture == layer_architecture
+    assert isinstance(config.transformer_layer_config, config_class)
+    assert config.transformer_layer_config.vocab_size == 32000
+    assert config.transformer_layer_config.hidden_size == 768
+    assert layer_architecture in config.architectures
 
 
 @pytest.mark.smoke
@@ -292,6 +457,44 @@ def test_eagle_speculator_config_marshalling(sample_speculators_config):
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_config_marshalling_different_layers(
+    layer_architecture, layer_configs, sample_speculators_config
+):
+    """Test marshalling with different layer architectures."""
+    layer_config = layer_configs[layer_architecture]
+
+    original_config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        layernorms=True,
+        fusion_bias=True,
+        speculators_config=sample_speculators_config,
+    )
+
+    # Test model_dump()
+    config_dict = original_config.model_dump()
+    assert isinstance(config_dict, dict)
+    assert config_dict["speculators_model_type"] == "eagle"
+    assert config_dict["transformer_layer_architecture"] == layer_architecture
+    assert layer_architecture in config_dict["architectures"]
+
+    # Test model_validate() on base class
+    recreated_base = SpeculatorModelConfig.model_validate(config_dict)
+    assert isinstance(recreated_base, EagleSpeculatorConfig)
+    assert recreated_base.transformer_layer_architecture == layer_architecture
+    assert recreated_base.layernorms is True
+    assert recreated_base.fusion_bias is True
+
+    # Test model_validate() roundtrip
+    recreated_config = EagleSpeculatorConfig.model_validate(config_dict)
+    assert isinstance(recreated_config, EagleSpeculatorConfig)
+    assert recreated_config.transformer_layer_architecture == layer_architecture
+    assert recreated_config.layernorms is True
+    assert recreated_config.fusion_bias is True
+
+
+@pytest.mark.smoke
 def test_eagle_speculator_config_model_validator():
     config1 = EagleSpeculatorConfig(transformer_layer_architecture="CustomDecoderLayer")
     assert "CustomDecoderLayer" in config1.architectures
@@ -316,6 +519,21 @@ def test_eagle_speculator_config_model_validator():
     assert "NewDecoderLayer" in config3.architectures
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_config_model_validator_different_layers(layer_architecture):
+    """Test model validator with different layer architectures."""
+    config = EagleSpeculatorConfig(transformer_layer_architecture=layer_architecture)
+
+    # Verify the layer architecture is added to architectures
+    assert layer_architecture in config.architectures
+    assert "EagleSpeculator" in config.architectures
+
+    # Verify no duplication occurs
+    architecture_count = config.architectures.count(layer_architecture)
+    assert architecture_count == 1
+
+
 # # ====== EagleSpeculatorConfig Eagle 1 / Eagle 2 Tests ======
 
 
@@ -338,6 +556,42 @@ def test_eagle_speculator_config_eagle12_backwards_compatibility(eagle12_config_
     assert config_base.layernorms is False
     assert config_base.fusion_bias is False
     assert config_base.speculators_config.algorithm == "eagle"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(("layer_architecture", "config_class"), LAYER_TYPES)
+def test_eagle_speculator_config_backwards_compatibility_different_layers(
+    layer_architecture, config_class, sample_speculators_config
+):
+    """Test backwards compatibility with different layer architectures."""
+    model_type = layer_architecture.lower().replace("decoderlayer", "")
+    if model_type == "deepseekv3":
+        model_type = "deepseek_v3"
+
+    config_dict = {
+        "speculators_model_type": "eagle",
+        "architectures": ["EagleSpeculator", layer_architecture],
+        "transformer_layer_architecture": layer_architecture,
+        "transformer_layer_config": {
+            "model_type": model_type,
+            "vocab_size": 32000,
+            "hidden_size": 768,
+            "intermediate_size": 3072,
+            "num_hidden_layers": 12,
+            "num_attention_heads": 12,
+            "max_position_embeddings": 2048,
+        },
+        "layernorms": False,
+        "fusion_bias": False,
+        "speculators_config": sample_speculators_config.model_dump(),
+    }
+
+    config = EagleSpeculatorConfig.model_validate(config_dict)
+    assert isinstance(config, EagleSpeculatorConfig)
+    assert config.speculators_model_type == "eagle"
+    assert config.transformer_layer_architecture == layer_architecture
+    assert layer_architecture in config.architectures
+    assert isinstance(config.transformer_layer_config, config_class)
 
 
 @pytest.mark.smoke
@@ -398,6 +652,40 @@ def test_eagle_speculator_config_eagle12_from_pretrained_local_marshalling(
         assert loaded_derived.transformer_layer_architecture == "LlamaDecoderLayer"
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_config_from_pretrained_different_layers(
+    layer_architecture, layer_configs, sample_speculators_config
+):
+    """Test from_pretrained with different layer architectures."""
+    layer_config = layer_configs[layer_architecture]
+
+    original_config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        layernorms=False,
+        fusion_bias=False,
+        speculators_config=sample_speculators_config,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Save with save_pretrained
+        original_config.save_pretrained(temp_path)
+
+        # Verify config.json was created
+        config_file = temp_path / "config.json"
+        assert config_file.exists()
+
+        # Load with from_pretrained
+        loaded_config = EagleSpeculatorConfig.from_pretrained(temp_path)
+        assert isinstance(loaded_config, EagleSpeculatorConfig)
+        assert loaded_config.speculators_model_type == "eagle"
+        assert loaded_config.transformer_layer_architecture == layer_architecture
+        assert layer_architecture in loaded_config.architectures
+
+
 # ====== EagleSpeculatorConfig HASS Tests ======
 
 
@@ -420,6 +708,29 @@ def test_eagle_speculator_config_hass_backwards_compatibility(hass_config_dict):
     assert config_base.layernorms is False
     assert config_base.fusion_bias is True  # Key difference for HASS
     assert config_base.speculators_config.algorithm == "eagle"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_config_hass_different_layers(
+    layer_architecture, layer_configs
+):
+    """Test HASS configuration with different layer architectures."""
+    layer_config = layer_configs[layer_architecture]
+
+    config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        layernorms=False,
+        fusion_bias=True,  # Key difference for HASS
+    )
+
+    assert isinstance(config, EagleSpeculatorConfig)
+    assert config.speculators_model_type == "eagle"
+    assert config.transformer_layer_architecture == layer_architecture
+    assert layer_architecture in config.architectures
+    assert config.fusion_bias is True  # Key difference for HASS
+    assert config.layernorms is False
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
Closes #44 

Expands support for other decoder layer types (MistralDecoderLayer, Qwen3DecoderLayer, etc.)
> # Tasks 
> * [x]   Research and identify transformer layer classes within Hugging Face for each targeted architecture.
> * [x]   Update `EagleSpeculatorConfig` to include architecture type selection.

This is handled using the existing `transformer_layer_architecture` field to specify the decoder layer class. 

The `transformer_layer_config` must also match the decoder layer type. i.e. to use `LlamaDecoderLayer` `transformer_layer_config` must be an instance of `LlamaConfig`, for `MistralDecoderLayer` it must be an instance of `MistralConfig`, etc.

> * [x]   Update `EagleSpeculator` to construct the selected transformer layer type correctly.

We find the corresponding decoder layer class (and also layer norm class), using the config class to determine the model type / import path. This generalizes the approach so that we can use **any** decoder layer and config combination in the transformers library.

> * [x]   Update or create relevant tests in:
>     * `tests/unit/models/test_eagle_config.py`
>     * `tests/unit/models/test_eagle_model.py`

Added explicit tests for the architectures listed in #44 (Llama, Mistral, Qwen, DeepSeek, Mistral, Gemma, Granite)

> * [x]   Ensure compatibility with `SpeculatorModelConfig.from_pretrained` and `SpeculatorModel.from_pretrained`.



