### PR TITLE
fixes for eagle3 converter

### DIFF
--- a/src/speculators/convert/eagle/eagle3_converter.py
+++ b/src/speculators/convert/eagle/eagle3_converter.py
@@ -18,7 +18,7 @@ from speculators.convert.eagle.utils import (
 )
 from speculators.models.eagle3 import Eagle3Speculator, Eagle3SpeculatorConfig
 from speculators.proposals.greedy import GreedyTokenProposalConfig
-
+from transformers import PretrainedConfig
 
 class Eagle3Converter:
     """
@@ -117,9 +117,10 @@ class Eagle3Converter:
         )
 
     def _create_verifier_config(self, eagle_config: dict, base_model: str) -> VerifierConfig:
+        config_dict, _ = PretrainedConfig.get_config_dict(base_model)
         return VerifierConfig(
             name_or_path=base_model,
-            architectures=eagle_config.get("architectures", ["LlamaForCausalLM"]),
+            architectures=config_dict.get("architectures", ["LlamaForCausalLM"]),
         )
 
     def _process_weights(self, weights: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:

--- a/src/speculators/convert/eagle/eagle3_converter.py
+++ b/src/speculators/convert/eagle/eagle3_converter.py
@@ -31,8 +31,9 @@ class Eagle3Converter:
         input_path: Union[str, Path],
         output_path: Union[str, Path],
         base_model: str,
-        fusion_bias: bool = False,
-        layernorms: bool = False,
+        # fusion_bias: bool = False,
+        # layernorms: bool = False,
+        norm_before_residual: bool = False,
         validate: bool = True,
         cache_dir: Optional[Union[str, Path]] = None,
     ) -> None:
@@ -47,16 +48,16 @@ class Eagle3Converter:
         # Patch: ensure target_vocab_size matches t2d tensor shape
         eagle_config["target_vocab_size"] = weights["t2d"].shape[0]
 
-        detected_fusion_bias, detected_layernorms = detect_fusion_bias_and_layernorms(
-            weights
-        )
-        fusion_bias = fusion_bias or detected_fusion_bias
-        layernorms = layernorms or detected_layernorms
+        # detected_fusion_bias, detected_layernorms = detect_fusion_bias_and_layernorms(
+        #     weights
+        # )
+        # fusion_bias = fusion_bias or detected_fusion_bias
+        # layernorms = layernorms or detected_layernorms
 
         config = self._build_eagle3_speculator_config(
-            eagle_config, base_model, fusion_bias, layernorms
+            eagle_config, base_model, norm_before_residual, #fusion_bias, layernorms,
         )
-        weights = self._process_weights(weights)
+        # weights = self._process_weights(weights)
 
         saved_path = self._save_converted_checkpoint(config, weights, output_path)
         logger.success(f"Saved to: {saved_path}")
@@ -69,8 +70,9 @@ class Eagle3Converter:
         self,
         eagle_config: dict,
         base_model: str,
-        fusion_bias: bool,
-        layernorms: bool,
+        norm_before_residual: bool = False,
+        # fusion_bias: bool,
+        # layernorms: bool,
     ) -> Eagle3SpeculatorConfig:
         transformer_config = self._create_transformer_config(eagle_config)
         verifier_config = self._create_verifier_config(eagle_config, base_model)
@@ -91,7 +93,7 @@ class Eagle3Converter:
             transformer_layer_config=transformer_config,
             speculators_config=speculators_config,
             draft_vocab_size=eagle_config.get("draft_vocab_size", 32000),
-            norm_before_residual=eagle_config.get("norm_before_residual", False),
+            norm_before_residual=norm_before_residual,
         )
 
     def _create_transformer_config(self, eagle_config: dict) -> LlamaConfig:

--- a/src/speculators/convert/eagle/eagle3_converter.py
+++ b/src/speculators/convert/eagle/eagle3_converter.py
@@ -94,6 +94,7 @@ class Eagle3Converter:
             speculators_config=speculators_config,
             draft_vocab_size=eagle_config.get("draft_vocab_size", 32000),
             norm_before_residual=norm_before_residual,
+            target_hidden_size=eagle_config.get("target_hidden_size"),
         )
 
     def _create_transformer_config(self, eagle_config: dict) -> LlamaConfig:

--- a/src/speculators/models/eagle.py
+++ b/src/speculators/models/eagle.py
@@ -10,20 +10,21 @@ Classes:
     EagleSpeculator: Main model implementation for EAGLE/HASS speculators
 """
 
+import importlib
+import inspect
 import os
+import re
+import warnings
 from typing import Any, ClassVar, Literal, Optional, Union
 
 import torch
 from pydantic import Field, field_serializer, field_validator, model_validator
 from torch import nn
-from transformers import PretrainedConfig, PreTrainedModel
+from transformers import AutoConfig, PretrainedConfig, PreTrainedModel
 from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
 from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
 from transformers.models.llama.configuration_llama import LlamaConfig
-from transformers.models.llama.modeling_llama import (
-    LlamaDecoderLayer,
-    LlamaRMSNorm,
-)
 from typing_extensions import Self
 
 from speculators import SpeculatorModel, SpeculatorModelConfig
@@ -83,7 +84,7 @@ class EagleSpeculatorConfig(SpeculatorModelConfig):
     )
 
     transformer_layer_architecture: str = Field(
-        default="LlamaDecoderLayer",
+        default="auto",
         description=(
             "The architecture class name of the transformer layer to use for "
             "the speculator's decoder layer. Must correspond to a valid "
@@ -131,7 +132,10 @@ class EagleSpeculatorConfig(SpeculatorModelConfig):
 
         :return: The validated configuration instance with updated architectures
         """
-        if self.transformer_layer_architecture not in self.architectures:
+        if (
+            self.transformer_layer_architecture != "auto"
+            and self.transformer_layer_architecture not in self.architectures
+        ):
             self.architectures.append(self.transformer_layer_architecture)
 
         return self
@@ -163,8 +167,7 @@ class EagleSpeculatorConfig(SpeculatorModelConfig):
         :raises ValueError: If the value cannot be converted to a PretrainedConfig
         """
         if isinstance(value, dict):
-            return PretrainedConfig.from_dict(value)
-
+            return AutoConfig.for_model(**value)
         if isinstance(value, PretrainedConfig):
             return value
 
@@ -289,6 +292,7 @@ class EagleSpeculator(SpeculatorModel):
             verifier_attachment_mode=verifier_attachment_mode,
         )
 
+        self._decoder_class, self._layernorm_class = self._import_model_classes()
         # Initialize layers based on the configuration
         self.embedding_layernorm: Optional[nn.Module] = self._create_layernorm()
         self.fusion_fc: nn.Linear = nn.Linear(
@@ -514,13 +518,12 @@ class EagleSpeculator(SpeculatorModel):
         if not self.config.layernorms:
             return None
 
-        return self._layernorm_class()(
+        return self._layernorm_class(
             self.hidden_size, eps=self.config.transformer_layer_config.rms_norm_eps
         )
 
     def _create_transformer_layer(self) -> nn.Module:
-        layer_class = self._transformer_layer_class()
-        layer = layer_class(
+        layer = self._decoder_class(
             self.config.transformer_layer_config,
             layer_idx=0,
         )
@@ -531,8 +534,84 @@ class EagleSpeculator(SpeculatorModel):
 
         return layer
 
-    def _layernorm_class(self) -> type[nn.Module]:
-        return LlamaRMSNorm
+    def _update_config_with_decoder_class(self, decoder_class: type[nn.Module]):
+        if self.config.transformer_layer_architecture == "auto":
+            decoder_name = decoder_class.__name__
+            self.config.transformer_layer_architecture = decoder_name
+            if decoder_name not in self.config.architectures:
+                self.config.architectures.append(decoder_name)
 
-    def _transformer_layer_class(self) -> type[nn.Module]:
-        return LlamaDecoderLayer
+    def _import_model_classes(self) -> tuple[type[nn.Module], type[nn.Module]]:
+        """
+        Get the decoder layer class and layer normalization class for a given config
+        and decoder layer name. Uses the config qualified name to find the corresponding
+        modeling module to import the decoder layer and normalization classes from.
+        """
+        # e.g. LlamaConfig + LlamaDecoderLayer
+        # -> get config class: transformers.models.llama.configuration_llama.LlamaConfig
+        # -> find corresponding causal language model class:
+        #       transformers.models.llama.modeling_llama.LlamaForCausalLM
+        # -> import module: transformers.models.llama.modeling_llama
+        # -> get decoder layer class:
+        #       transformers.models.llama.modeling_llama.LlamaDecoderLayer
+        # -> get layer normalization class:
+        #       transformers.models.llama.modeling_llama.LlamaRMSNorm
+
+        config_class = type(self.config.transformer_layer_config)
+        if config_class not in MODEL_FOR_CAUSAL_LM_MAPPING:
+            raise TypeError(
+                f"Config class {config_class} is not a valid causal language model "
+                f"config class. Please use a valid config, e.g., LlamaConfig."
+            )
+
+        causal_lm_model_class = MODEL_FOR_CAUSAL_LM_MAPPING[config_class]
+        module_path = causal_lm_model_class.__module__
+
+        # Import the modeling module
+        modeling_module = importlib.import_module(module_path)
+
+        ### Get decoder layer class
+        transformer_arch_name = self.config.transformer_layer_architecture
+        if transformer_arch_name == "auto":
+            transformer_arch_name = (
+                config_class.__name__.removesuffix("Config") + "DecoderLayer"
+            )
+
+        try:
+            decoder_class = getattr(modeling_module, transformer_arch_name)
+        except AttributeError as e:
+            if self.config.transformer_layer_architecture == "auto":
+                msg = (
+                    "Unable to automatically determine transformer layer architecture. "
+                    "Please set `transformer_layer_architecture` to a valid "
+                    "architecture, e.g., 'LlamaDecoderLayer' for Llama models."
+                )
+            else:
+                msg = (
+                    f"Transformer layer architecture {transformer_arch_name} not found "
+                    f"in module {module_path}. Please set "
+                    "`transformer_layer_architecture` to a valid architecture, "
+                    "e.g., 'LlamaDecoderLayer' for Llama models."
+                )
+            raise ValueError(msg) from e
+
+        self._update_config_with_decoder_class(decoder_class)
+
+        ### Get layer normalization class
+        if not self.config.layernorms:
+            # No layernorms being used, so no need to import a layer normalization class
+            return decoder_class, nn.Identity
+
+        classes = dict(inspect.getmembers(modeling_module, inspect.isclass))
+        for pat in [r".*RMSNorm$", r".*Norm$"]:
+            for name, cls in classes.items():
+                if re.match(pat, name):
+                    return decoder_class, cls
+
+        warnings.warn(
+            "Unable to automatically determine layer normalization class. "
+            "Falling back to torch.nn.LayerNorm.",
+            stacklevel=2,
+        )
+
+        return decoder_class, torch.nn.LayerNorm

--- a/tests/unit/models/test_eagle_model.py
+++ b/tests/unit/models/test_eagle_model.py
@@ -10,12 +10,37 @@ import pytest
 import torch
 from torch import nn
 from transformers import PreTrainedModel
+from transformers.configuration_utils import PretrainedConfig
+from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
+    DeepseekV3DecoderLayer,
+    DeepseekV3RMSNorm,
+)
+from transformers.models.gemma.configuration_gemma import GemmaConfig
+from transformers.models.gemma.modeling_gemma import GemmaDecoderLayer, GemmaRMSNorm
+from transformers.models.granite.configuration_granite import GraniteConfig
+from transformers.models.granite.modeling_granite import (
+    GraniteDecoderLayer,
+    GraniteRMSNorm,
+)
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import (
     LlamaDecoderLayer,
     LlamaRMSNorm,
     LlamaRotaryEmbedding,
 )
+from transformers.models.mistral.configuration_mistral import MistralConfig
+from transformers.models.mistral.modeling_mistral import (
+    MistralDecoderLayer,
+    MistralRMSNorm,
+)
+from transformers.models.mixtral.configuration_mixtral import MixtralConfig
+from transformers.models.mixtral.modeling_mixtral import (
+    MixtralDecoderLayer,
+    MixtralRMSNorm,
+)
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+from transformers.models.qwen3.modeling_qwen3 import Qwen3DecoderLayer, Qwen3RMSNorm
 
 from speculators import (
     SpeculatorModel,
@@ -24,6 +49,25 @@ from speculators import (
 )
 from speculators.models import EagleSpeculator, EagleSpeculatorConfig
 from speculators.proposals import GreedyTokenProposalConfig
+
+# ===== Layer Types Constants =====
+
+LAYER_TYPES: dict[str, tuple[type, type, type]] = {
+    # Format: "LayerName": (LayerClass, NormClass, ConfigClass)
+    "LlamaDecoderLayer": (LlamaDecoderLayer, LlamaRMSNorm, LlamaConfig),
+    "MistralDecoderLayer": (MistralDecoderLayer, MistralRMSNorm, MistralConfig),
+    "Qwen3DecoderLayer": (Qwen3DecoderLayer, Qwen3RMSNorm, Qwen3Config),
+    "GemmaDecoderLayer": (GemmaDecoderLayer, GemmaRMSNorm, GemmaConfig),
+    "MixtralDecoderLayer": (MixtralDecoderLayer, MixtralRMSNorm, MixtralConfig),
+    "DeepseekV3DecoderLayer": (
+        DeepseekV3DecoderLayer,
+        DeepseekV3RMSNorm,
+        DeepseekV3Config,
+    ),
+    "GraniteDecoderLayer": (GraniteDecoderLayer, GraniteRMSNorm, GraniteConfig),
+}
+
+LAYER_ARCHITECTURES = list(LAYER_TYPES.keys())
 
 # ===== Test Helper Classes =====
 
@@ -80,6 +124,37 @@ def sample_llama_config():
         use_cache=True,
         vocab_size=128256,
     )
+
+
+# ===== Config Helper Function =====
+
+
+def create_layer_config_for_architecture(layer_architecture: str):
+    config_class = LAYER_TYPES[layer_architecture][
+        2
+    ]  # Third element is the config class
+    base_params = {
+        "vocab_size": 32000,
+        "hidden_size": 768,
+        "intermediate_size": 3072,
+        "num_hidden_layers": 12,
+        "num_attention_heads": 12,
+        "max_position_embeddings": 2048,
+    }
+
+    # Add extra parameters for specific config types
+    if config_class in (MixtralConfig, DeepseekV3Config, GraniteConfig):
+        base_params["num_key_value_heads"] = 12
+
+    if config_class == MixtralConfig:
+        base_params.update(
+            {
+                "num_local_experts": 8,
+                "num_experts_per_tok": 2,
+            }
+        )
+
+    return config_class(**base_params)
 
 
 @pytest.fixture
@@ -416,3 +491,316 @@ def test_eagle_speculator_architecture_hass(
     assert isinstance(model.transformer.input_layernorm, LlamaRMSNorm)
     assert model.pre_lm_head_layernorm is not None
     assert isinstance(model.pre_lm_head_layernorm, LlamaRMSNorm)
+
+
+# ===== EagleSpeculator Architecture Tests with Different Layer Types =====
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_initialization_different_layers(
+    layer_architecture, sample_speculators_config
+):
+    """Test EagleSpeculator initialization with different layer architectures."""
+    layer_config = create_layer_config_for_architecture(layer_architecture)
+
+    # Create EagleSpeculatorConfig with the specific layer architecture
+    eagle_config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        speculators_config=sample_speculators_config,
+    )
+
+    # Create mock verifier for this config
+    mock_verifier = MockVerifier(layer_config)
+
+    model = EagleSpeculator(eagle_config, verifier=mock_verifier)
+
+    assert model.config == eagle_config
+    assert model.verifier == mock_verifier
+    assert model.verifier_attachment_mode == "full"
+
+    # Verify basic architecture
+    assert model.embed_tokens is not None
+    assert model.embed_tokens == mock_verifier.embed_tokens
+    assert model.rotary_emb is not None
+    assert model.rotary_emb == mock_verifier.rotary_emb
+    assert model.lm_head is not None
+    assert model.lm_head == mock_verifier.lm_head
+    assert model.fusion_fc is not None
+    assert model.transformer is not None
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_architecture_different_layers(
+    layer_architecture, sample_speculators_config
+):
+    """Test EagleSpeculator architecture with different layer types."""
+    layer_config = create_layer_config_for_architecture(layer_architecture)
+
+    # Create EagleSpeculatorConfig with the specific layer architecture
+    eagle_config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        speculators_config=sample_speculators_config,
+    )
+
+    # Create mock verifier for this config
+    mock_verifier = MockVerifier(layer_config)
+
+    model = EagleSpeculator(
+        eagle_config, verifier=mock_verifier, verifier_attachment_mode="full"
+    )
+
+    assert isinstance(model, EagleSpeculator)
+    assert isinstance(model.config, EagleSpeculatorConfig)
+
+    # Verify embedding layer
+    assert model.embed_tokens is not None
+    assert isinstance(model.embed_tokens, nn.Embedding)
+    assert model.embed_tokens.weight.shape == (
+        layer_config.vocab_size,
+        layer_config.hidden_size,
+    )
+
+    # Verify rotary embedding
+    assert model.rotary_emb is not None
+    assert isinstance(model.rotary_emb, LlamaRotaryEmbedding)
+
+    # Verify language model head
+    assert model.lm_head is not None
+    assert isinstance(model.lm_head, nn.Linear)
+    assert model.lm_head.weight.shape == (
+        layer_config.vocab_size,
+        layer_config.hidden_size,
+    )
+    assert model.lm_head.bias is None
+
+    # Verify fusion layer
+    assert model.fusion_fc is not None
+    assert isinstance(model.fusion_fc, nn.Linear)
+    assert model.fusion_fc.weight.shape == (
+        layer_config.hidden_size,
+        2 * layer_config.hidden_size,
+    )
+    assert model.fusion_fc.bias is None
+
+    # Verify transformer layer
+    assert model.transformer is not None
+    assert isinstance(model.transformer, LAYER_TYPES[layer_architecture][0])
+    assert model.transformer.self_attn.config.hidden_size == layer_config.hidden_size
+
+    # Verify no layernorms by default
+    assert model.embedding_layernorm is None
+    assert model.pre_lm_head_layernorm is None
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_architecture_different_layers_with_layernorms(
+    layer_architecture, sample_speculators_config
+):
+    """Test EagleSpeculator with layernorms enabled for different decoder layers."""
+    layer_config = create_layer_config_for_architecture(layer_architecture)
+
+    # Create EagleSpeculatorConfig with layernorms enabled
+    eagle_config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        speculators_config=sample_speculators_config,
+        layernorms=True,
+        fusion_bias=True,
+    )
+
+    # Create mock verifier for this config
+    mock_verifier = MockVerifier(layer_config)
+
+    model = EagleSpeculator(
+        eagle_config, verifier=mock_verifier, verifier_attachment_mode="full"
+    )
+
+    assert isinstance(model, EagleSpeculator)
+    assert isinstance(model.config, EagleSpeculatorConfig)
+
+    # Verify embedding layer
+    assert model.embed_tokens is not None
+    assert isinstance(model.embed_tokens, nn.Embedding)
+    assert model.embed_tokens.weight.shape == (
+        layer_config.vocab_size,
+        layer_config.hidden_size,
+    )
+
+    # Verify embedding layernorm
+    assert model.embedding_layernorm is not None
+    assert isinstance(model.embedding_layernorm, LAYER_TYPES[layer_architecture][1])
+    assert model.embedding_layernorm.weight.shape == (layer_config.hidden_size,)  # type: ignore[attr-defined]
+
+    # Verify fusion layer with bias
+    assert model.fusion_fc is not None
+    assert isinstance(model.fusion_fc, nn.Linear)
+    assert model.fusion_fc.weight.shape == (
+        layer_config.hidden_size,
+        2 * layer_config.hidden_size,
+    )
+    assert model.fusion_fc.bias is not None
+
+    # Verify pre-lm-head layernorm
+    assert model.pre_lm_head_layernorm is not None
+    assert isinstance(model.pre_lm_head_layernorm, LAYER_TYPES[layer_architecture][1])
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_from_pretrained_different_layers(
+    layer_architecture, sample_speculators_config
+):
+    """Test EagleSpeculator from_pretrained with different layer architectures."""
+    layer_config = create_layer_config_for_architecture(layer_architecture)
+
+    # Create EagleSpeculatorConfig with the specific layer architecture
+    eagle_config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        speculators_config=sample_speculators_config,
+    )
+
+    # Create state dict from a detached model
+    state_dict = EagleSpeculator(
+        eagle_config, verifier_attachment_mode="detached"
+    ).state_dict()
+
+    # Create mock verifier for this config
+    mock_verifier = MockVerifier(layer_config)
+
+    # Load model using from_pretrained
+    model = SpeculatorModel.from_pretrained(
+        None,
+        config=eagle_config,
+        verifier=mock_verifier,
+        state_dict=state_dict,
+    )
+
+    assert isinstance(model, EagleSpeculator)
+    assert model.config.transformer_layer_architecture == layer_architecture
+    assert model.verifier == mock_verifier
+    assert model.verifier_attachment_mode == "full"
+    assert model.embed_tokens == mock_verifier.embed_tokens
+    assert model.rotary_emb == mock_verifier.rotary_emb
+    assert model.lm_head == mock_verifier.lm_head
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("layer_architecture", LAYER_ARCHITECTURES)
+def test_eagle_speculator_local_marshalling_different_layers(
+    layer_architecture, sample_speculators_config
+):
+    """Test EagleSpeculator local marshalling with different layer architectures."""
+    layer_config = create_layer_config_for_architecture(layer_architecture)
+
+    # Create EagleSpeculatorConfig with the specific layer architecture
+    eagle_config = EagleSpeculatorConfig(
+        transformer_layer_architecture=layer_architecture,
+        transformer_layer_config=layer_config,
+        speculators_config=sample_speculators_config,
+    )
+
+    # Create state dict from a detached model
+    state_dict = EagleSpeculator(
+        eagle_config, verifier_attachment_mode="detached"
+    ).state_dict()
+
+    # Create mock verifier for this config
+    mock_verifier = MockVerifier(layer_config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create and save model
+        model = SpeculatorModel.from_pretrained(
+            None,
+            config=eagle_config,
+            verifier=mock_verifier,
+            state_dict=state_dict,
+        )
+        model.save_pretrained(tmpdir)  # type: ignore[attr-defined]
+
+        # Load model from saved directory
+        loaded_model = SpeculatorModel.from_pretrained(tmpdir, verifier=mock_verifier)
+
+        assert isinstance(loaded_model, EagleSpeculator)
+        assert isinstance(loaded_model.config, EagleSpeculatorConfig)
+        assert loaded_model.config.transformer_layer_architecture == layer_architecture
+        assert loaded_model.verifier == mock_verifier
+        assert loaded_model.verifier_attachment_mode == "full"
+        assert loaded_model.embed_tokens == mock_verifier.embed_tokens
+        assert loaded_model.rotary_emb == mock_verifier.rotary_emb
+        assert loaded_model.lm_head == mock_verifier.lm_head
+
+
+# ===== EagleSpeculator Architecture Auto-Detection Tests =====
+
+
+@pytest.mark.smoke
+def test_eagle_speculator_auto_architecture_derivation(sample_speculators_config):
+    layer_config = LlamaConfig()
+
+    # Create config with auto architecture
+    eagle_config = EagleSpeculatorConfig(
+        transformer_layer_architecture="auto",
+        transformer_layer_config=layer_config,
+        speculators_config=sample_speculators_config,
+    )
+
+    # Create mock verifier
+    mock_verifier = MockVerifier(layer_config)
+
+    # Create model - this should work with auto architecture
+    model = EagleSpeculator(eagle_config, verifier=mock_verifier)
+
+    # Verify the model was created successfully
+    assert isinstance(model, EagleSpeculator)
+    # This value is set during initialization when a decoder layer class is found
+    assert model.config.transformer_layer_architecture == "LlamaDecoderLayer"
+    assert "LlamaDecoderLayer" in model.config.architectures
+    assert model.verifier == mock_verifier
+    assert model.verifier_attachment_mode == "full"
+
+    # Verify the transformer layer is the correct type
+    assert isinstance(model.transformer, LlamaDecoderLayer)
+
+
+@pytest.mark.smoke
+def test_eagle_speculator_auto_architecture_error_handling():
+    # Create a custom config class that doesn't have a corresponding decoder layer
+    class CustomConfig(PretrainedConfig):
+        model_type = "custom"
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.vocab_size = 32000
+            self.hidden_size = 768
+            self.intermediate_size = 3072
+            self.num_hidden_layers = 12
+            self.num_attention_heads = 12
+            self.max_position_embeddings = 2048
+
+    # This config is not in MODEL_FOR_CAUSAL_LM_MAPPING, so it should fail
+    custom_config = CustomConfig()
+
+    eagle_config = EagleSpeculatorConfig(
+        transformer_layer_architecture="auto",
+        transformer_layer_config=custom_config,
+        speculators_config=SpeculatorsConfig(
+            algorithm="eagle",
+            proposal_methods=[GreedyTokenProposalConfig()],
+            default_proposal_method="greedy",
+            verifier=VerifierConfig(
+                name_or_path="test/verifier",
+                architectures=["CustomForCausalLM"],
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        TypeError, match="is not a valid causal language model config class"
+    ):
+        EagleSpeculator(eagle_config, verifier_attachment_mode="detached")


### PR DESCRIPTION
```python
from speculators.convert.eagle.eagle3_converter import Eagle3Converter

converter = Eagle3Converter()
converter.convert(
    input_path="nm-testing/SpeculatorLlama3-1-8B-Eagle3",
    base_model="meta-llama/Meta-Llama-3.1-8B-Instruct",
    output_path="eagle3-llama3.1-8b-instruct-speculators",
    norm_before_residual=True,
)
```

Converted Model: https://huggingface.co/nm-testing/eagle3-llama3.1-8b-instruct-speculators