### PR TITLE
override transformer tie_weights to prevent shape mismatch

### DIFF
--- a/src/speculators/models/eagle3.py
+++ b/src/speculators/models/eagle3.py
@@ -553,3 +553,18 @@ class Eagle3Speculator(SpeculatorModel):
         :return: Boolean mask indicating availability in draft vocabulary
         """
         return self.t2d[target_tokens]  # type: ignore[return-value]
+
+    def tie_weights(self):
+        """
+        Override tie_weights to prevent vocabulary corruption in transformers 4.54.1+
+        
+        Eagle3 intentionally uses different vocabulary sizes:
+        - Input embeddings (embed_tokens): 128256 (full vocabulary)  
+        - Output embeddings (lm_head): 32000 (draft vocabulary)
+        
+        The default tie_weights() tries to make them identical, breaking Eagle3.
+        This override preserves the intentional vocabulary size difference.
+        """
+        # Don't call super().tie_weights() - this prevents the vocabulary corruption
+        # that occurs when _tie_or_clone_weights replaces lm_head.weight with embed_tokens.weight
+        pass


### PR DESCRIPTION
## Issue

Main was failing on the new transformer version `4.54.1` with the following error:
```
✗ Conversion failed: Error(s) in loading state_dict for Eagle3Speculator:
        size mismatch for lm_head.weight: copying a param with shape torch.Size([32000, 4096]) from checkpoint, the shape in current model is torch.Size([128256, 4096]).
```
The [`tie_weights()`](https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L3051) function in transformers 4.54.1+ aggressively "fixes" perceived vocabulary inconsistencies. Eagle3 intentionally uses different input/output vocabulary sizes. The `_tie_or_clone_weights()` function replaces `lm_head.weight` with `embed_tokens.weight`. (Eagle3.init() -> post_init() -> init_weights() -> tie_weights() -> tie_or_clone_weights())

## Change
**Override `tie_weights()` in `Eagle3Speculator` to prevent vocabulary corruption**
Added a simple override that disables the problematic weight tie. 

## Test
Ran the following command on main with transformer 4.54.1:
```
speculators convert nm-testing/SpeculatorLlama3-1-8B-Eagle3 SpeculatorLlama3-1-8B-Eagle3-converted meta-llama/Meta-Llama-3.1-8B-Instruct --eagle3
```
and converted model successfully. 