### PR TITLE
Polish Eagle3 config and model definitions

### DIFF
--- a/src/speculators/convert/eagle/eagle3_converter.py
+++ b/src/speculators/convert/eagle/eagle3_converter.py
@@ -178,9 +178,7 @@ class Eagle3Converter:
         return Eagle3SpeculatorConfig(
             transformer_layer_config=transformer_config,
             speculators_config=speculators_config,
-            draft_vocab_size=eagle_config.get("draft_vocab_size", 32000),
             norm_before_residual=norm_before_residual,
-            target_hidden_size=eagle_config.get("target_hidden_size"),
         )
 
     def _create_transformer_config_from_eagle(


### PR DESCRIPTION
## Description

- Share code between Eagle and Eagle3 implementations as base class to minimize redundancy
- Remove redundant params and source as much info from the transformers config as possible
- Remove current implementation for token mappings/head pruning, more needs to be worked in to solidify the direction and implementation there
- Minor cleanup for eagle3 module